### PR TITLE
Patch for python3

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,13 @@
+# .github/workflows/tagpr.yml
+name: tagpr
+on:
+  push:
+    branches: ["master"]
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Songmu/tagpr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/sdag.py
+++ b/sdag.py
@@ -146,21 +146,21 @@ class SLURM_DAGMan(object):
 ######################################################################
 def main(argv):
     if len(argv) != 1:
-        print 'Missing argument: DAG description file'
+        print('Missing argument: DAG description file')
         sys.exit()
     arg = argv[0]
     if arg in ['-h','--help']:
-        print 'A simple DAG manager for SLURM.'
+        print('A simple DAG manager for SLURM.')
         sys.exit()
     else:
         dagFile = arg
         if not os.path.isfile(dagFile):
-            print 'Error: You must enter a valid DAG description file'
+            print('Error: You must enter a valid DAG description file')
             sys.exit(1)
         dagman = SLURM_DAGMan(dagFile)
         dagman.parse()
         dagman.run()
-        print dagman
+        print(dagman)
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
Patched sdag.py to be python3 compatible. Python2 is EOL and should not be used, and python3 is now more wide spread than python2. If this software is used in locations where python3 is not available, this patch could be applied to a different branch?
Patch is tested with python3.8.6 on fox educloud. 